### PR TITLE
Display default city and not undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
         const searchBox = document.querySelector('.search input');
         const searchBtn = document.querySelector('.search button');
         
-        async function checkWeather(city) {
+        async function checkWeather(city = Nairobi) {
             const response = await fetch(apiUrl + city +  `&appid=${apiKey}`);
             var data = await response.json();
 


### PR DESCRIPTION
The checkWeather function is being called without any arguments when the page loads, which results in an undefined city being used in the API call. To fix this, I provided a default city when the checkWeather function is called without arguments.

